### PR TITLE
Bad link (404) in readme.md - MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ Bucket           #      %        Histogram
 
 ## License
 
-[MIT](/MIT)
+[MIT](/LICENSE)


### PR DESCRIPTION
[MIT](/MIT)
https://github.com/github/fiber-fragments/blob/main/MIT
404 Not Found.

I assume this should point to the "LICENCE" file.

However note there is another MIT link higher up in this readme pointing to "https://opensource.org/licenses/MIT" so there is some inconsistencies in this readme that perhaps merits a separate Issue?